### PR TITLE
fix(energy-core): report wraps that can't be measured without a bound

### DIFF
--- a/packages/energy-core/src/sensors/rapl/EmpiricalEnergyReader.ts
+++ b/packages/energy-core/src/sensors/rapl/EmpiricalEnergyReader.ts
@@ -131,7 +131,8 @@ export class EmpiricalEnergyReader {
                 deltaJ: 0,
                 deltaUj: 0,
                 packages: [],
-                wraps: 0
+                wraps: 0,
+                unhandledWraps:0,
             }
         }
 
@@ -143,7 +144,8 @@ export class EmpiricalEnergyReader {
                 deltaJ: 0,
                 deltaUj: 0,
                 packages: [],
-                wraps: 0
+                wraps: 0,
+                unhandledWraps:0,
             }
         }
 
@@ -175,6 +177,7 @@ export class EmpiricalEnergyReader {
             deltaJ,
             packages: [],
             wraps: 0,
+            unhandledWraps:0,
         }
     }
 

--- a/packages/energy-core/src/sensors/rapl/RaplReader.test.ts
+++ b/packages/energy-core/src/sensors/rapl/RaplReader.test.ts
@@ -31,6 +31,7 @@ test('RaplReader - sample energy consumption', async (t) => {
                 deltaJ:0,
                 deltaUj:0,
                 wraps:0,
+                unhandledWraps:0,
                 ok:true
             };
             const expectedPrime = {
@@ -43,7 +44,8 @@ test('RaplReader - sample energy consumption', async (t) => {
                 packages: [
                     expectedPackage
                 ],
-                wraps: 0
+                wraps: 0,
+                unhandledWraps:0
             }
             assert.ok(sample);
             assert.deepStrictEqual(sample, expectedPrime);
@@ -92,10 +94,12 @@ test('RaplReader - sample energy consumption', async (t) => {
                         deltaJ: 2,
                         deltaUj: 2000000,
                         wraps: 0,
+                        unhandledWraps:0,
                         ok: true
                     }
                 ],
-                wraps: 0
+                wraps: 0,
+                unhandledWraps:0
             }
             assert.ok(sample);
             assert.deepStrictEqual(sample, expectedSecond);
@@ -142,10 +146,12 @@ test('RaplReader - sample energy consumption', async (t) => {
                         deltaJ: 2,
                         deltaUj: 2000000,
                         wraps: 1,
+                        unhandledWraps:0,
                         ok: true
                     }
                 ],
-                wraps: 1
+                wraps: 1,
+                unhandledWraps:0,
             }
             assert.ok(sample);
             assert.deepStrictEqual(sample, expectedWrap);
@@ -202,6 +208,7 @@ test('RaplReader - sample energy consumption', async (t) => {
                         deltaJ: 2,
                         deltaUj: 2000000,
                         wraps: 0,
+                        unhandledWraps:0,
                         ok: true
                     },
                     {
@@ -210,11 +217,13 @@ test('RaplReader - sample energy consumption', async (t) => {
                         deltaJ: 2,
                         deltaUj: 2000000,
                         wraps: 0,
+                        unhandledWraps:0,
                         ok: true
                     }
 
                 ],
-                wraps: 0
+                wraps: 0,
+                unhandledWraps:0
             }
             assert.ok(sample);
             assert.deepStrictEqual(sample, expectedMulti);
@@ -231,7 +240,7 @@ test('RaplReader - sample energy consumption', async (t) => {
             await mkdir(path.join(temp, `intel-rapl:0`), { recursive: true });
             await writeFile(path.join(temp, `intel-rapl:0`, 'name'), 'package-0', 'utf8');
 
-            
+
 
             const probe = await raplProbe(temp);
             raplReader = new RaplReader({ probe, log: 'silent' });
@@ -252,7 +261,7 @@ test('RaplReader - sample energy consumption', async (t) => {
                 createRaplPackages(temp, 'intel-rapl:0', { name: 'package-0', energy: 1_000_000n }),
                 createRaplPackages(temp, 'intel-rapl:1', { name: 'package-1', energy: 2_000_000n })
             ]
-        );  
+        );
             //remove read permissions
             if (p1.files.energyPath) {
                 await chmod(p1.files.energyPath, 0o000);
@@ -262,7 +271,7 @@ test('RaplReader - sample energy consumption', async (t) => {
             //first sample to prime
             let dt = nowNs(0);
             const sample = await raplReader.sample(dt);
-            await writeFile(p0.files.energyPath, String(1_500_000n), 'utf8');           
+            await writeFile(p0.files.energyPath, String(1_500_000n), 'utf8');
             //second sample after 1s
             dt = nowNs(1.0);
             const sample2 = await raplReader.sample(dt);
@@ -277,7 +286,7 @@ test('RaplReader - sample energy consumption', async (t) => {
     });
 });
 
-test('clampDt utility function', async (t) => { 
+test('clampDt utility function', async (t) => {
 
     await t.test('CLAMP DT: clamp delta time between min and max thresholds', async () => {
         assert.strictEqual(clampDt(-1), 0.2);

--- a/packages/energy-core/src/sensors/rapl/RaplReader.ts
+++ b/packages/energy-core/src/sensors/rapl/RaplReader.ts
@@ -13,6 +13,7 @@ export interface RaplPackageSample {
     deltaUj: number; // µJ
     deltaJ: number;  // J
     wraps: number;
+    unhandledWraps: number; // wrap détecté mais non mesurable (borne inconnue)
     ok: boolean;     // lecture OK pour ce package sur ce tick ?
 }
 export interface RaplSample {
@@ -23,6 +24,7 @@ export interface RaplSample {
     deltaJ: number;    // J
     packages: RaplPackageSample[];
     wraps: number;
+    unhandledWraps: number; // total des wraps non mesurables sur ce tick
 }
 
 interface RaplReaderPackageState {
@@ -102,7 +104,7 @@ export class RaplReader {
                 name: p.name,
                 file: p.files.energyUj!,
                 lastUj: null,
-                maxEnergyUj:p.maxEnergyUj,
+                maxEnergyUj: p.maxEnergyUj,
             })),
         };
     }
@@ -161,6 +163,7 @@ export class RaplReader {
                 deltaUj: 0,
                 deltaJ: 0,
                 wraps: 0,
+                unhandledWraps:0,
                 ok,
             }));
 
@@ -175,6 +178,7 @@ export class RaplReader {
                 deltaJ: 0,
                 packages,
                 wraps: 0,
+                unhandledWraps:0,
             };
         }
 
@@ -188,6 +192,7 @@ export class RaplReader {
         }
 
         let wraps = 0n;
+        let unhandledWraps = 0n;
         let totalDeltaUj = 0n;
         let primed = false;
         let successfulReads = 0;
@@ -215,6 +220,7 @@ export class RaplReader {
             // read result for this package
             let pkgDeltaUj = 0n;
             let pkgWraps = 0n;
+            let pkgUnhandledWraps = 0n;
             let pkgOk = false;
 
             if (result.ok) {
@@ -232,10 +238,18 @@ export class RaplReader {
                     let deltaUj = currentUj - pkg.lastUj;
 
                     // wraparound
-                    if (deltaUj < 0n && pkg.maxEnergyUj !== null) {
-                        wraps += 1n;
-                        pkgWraps += 1n;
-                        deltaUj = (pkg.maxEnergyUj - pkg.lastUj) + currentUj;
+                    if (deltaUj < 0n) {
+
+                        if (pkg.maxEnergyUj !== null) {
+                            wraps += 1n;
+                            pkgWraps += 1n;
+                            deltaUj = (pkg.maxEnergyUj - pkg.lastUj) + currentUj;
+                        } else {
+                            unhandledWraps += 1n;
+                            pkgUnhandledWraps += 1n;
+                            deltaUj = 0n;
+                        }
+
                     }
 
                     if (deltaUj >= 0n) {
@@ -256,6 +270,7 @@ export class RaplReader {
                 deltaUj: deltaUjNumber,
                 deltaJ,
                 wraps: Number(pkgWraps),
+                unhandledWraps:Number(pkgUnhandledWraps),
                 ok: pkgOk,
             });
         }
@@ -272,6 +287,7 @@ export class RaplReader {
                 deltaJ: 0,
                 packages: packageSamples,
                 wraps: Number(wraps),
+                unhandledWraps:Number(unhandledWraps)
             };
         }
 
@@ -286,6 +302,7 @@ export class RaplReader {
             deltaJ: totalDeltaJ,
             packages: packageSamples,
             wraps: Number(wraps),
+            unhandledWraps:Number(unhandledWraps)
         };
     }
 

--- a/packages/energy-core/src/sensors/rapl/RaplReader.unhandled-wrap.test.ts
+++ b/packages/energy-core/src/sensors/rapl/RaplReader.unhandled-wrap.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import os from 'node:os';
+import { chmod, rm, writeFile } from 'node:fs/promises';
+import { RaplReader } from './RaplReader.js';
+import { raplProbe } from './rapl-probe.js';
+import { createRaplPackages, nowNs } from '../../utils/test-utils.js';
+
+
+test('RaplReader - wrap without a known bound is reported, not silently zeroed', async () => {
+    const temp = path.join(os.tmpdir(), `rapl-unhandled-wrap-${process.pid}`);
+    try {
+        // No maxRange => the fixture does not create max_energy_range_uj,
+        // so the probe yields maxEnergyUj = null (CPU without a known bound).
+        const pkg = await createRaplPackages(temp, 'intel-rapl:0', {
+            name: 'package-0',
+            energy: 19000000n,
+        });
+
+        const probe = await raplProbe(temp);
+        const reader = new RaplReader({ probe, log: 'silent' });
+
+        // Prime.
+        await reader.sample(nowNs(0));
+
+        // Simulate a wrap: the counter jumps backwards.
+        await chmod(pkg.files.energyPath, 0o644);
+        await writeFile(pkg.files.energyPath, String(1000000n), 'utf8');
+
+        const sample = await reader.sample(nowNs(1.0));
+
+        assert.ok(sample);
+        // We cannot compute the energy of this tick without a bound:
+        // the delta must stay 0 (we invent nothing).
+        assert.strictEqual(sample.deltaUj, 0);
+        assert.strictEqual(sample.packages[0].deltaUj, 0);
+        // But the event must be visible, not lost:
+        assert.strictEqual(sample.unhandledWraps, 1);
+        assert.strictEqual(sample.packages[0].unhandledWraps, 1);
+        // And it must NOT be counted as a corrected wrap:
+        assert.strictEqual(sample.wraps, 0);
+        assert.strictEqual(sample.packages[0].wraps, 0);
+    } finally {
+        await rm(temp, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
When a RAPL counter wraps but max_energy_range_uj is unavailable, the energy of that tick cannot be computed. The reader used to drop it silently (0 J). Now it forces deltaUj to 0 (inventing nothing) but surfaces the event via a new unhandledWraps counter, per package and per sample, kept distinct from corrected wraps. Empirical fallback reports 0. Leaves room for a default-bound estimation later.