### PR TITLE
fix(energy-core): report partial package reads instead of hiding them

### DIFF
--- a/packages/energy-core/src/sensors/rapl/EmpiricalEnergyReader.ts
+++ b/packages/energy-core/src/sensors/rapl/EmpiricalEnergyReader.ts
@@ -133,6 +133,8 @@ export class EmpiricalEnergyReader {
                 packages: [],
                 wraps: 0,
                 unhandledWraps:0,
+                expectedPackages:0,
+                readablePackages:0
             }
         }
 
@@ -146,6 +148,8 @@ export class EmpiricalEnergyReader {
                 packages: [],
                 wraps: 0,
                 unhandledWraps:0,
+                expectedPackages:0,
+                readablePackages:0
             }
         }
 
@@ -178,6 +182,8 @@ export class EmpiricalEnergyReader {
             packages: [],
             wraps: 0,
             unhandledWraps:0,
+            expectedPackages:0,
+            readablePackages:0
         }
     }
 

--- a/packages/energy-core/src/sensors/rapl/RaplReader.partial.test.ts
+++ b/packages/energy-core/src/sensors/rapl/RaplReader.partial.test.ts
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import os from 'node:os';
+import { chmod, rm, writeFile } from 'node:fs/promises';
+import { RaplReader } from './RaplReader.js';
+import { raplProbe } from './rapl-probe.js';
+import { createRaplPackages, nowNs } from '../../utils/test-utils.js';
+
+// Moment 1 : un package est déjà illisible au démarrage (au probe).
+// Le matériel expose 2 packages, un seul est lisible.
+// Choix honnête : expectedPackages doit rester à 2.
+
+test('RaplReader - package unreadable at probe time is still counted as expected', async() => {
+    const tmp = path.join(os.tmpdir(), `rapl-partial-probe-${process.pid}`);
+    try {
+
+        const [p0,p1] = await Promise.all([
+             createRaplPackages(tmp,'intel-rapl:0',{name:'package-0',energy:1_000_000n}),
+            createRaplPackages(tmp,'intel-rapl:1',{name:'package-0',energy:2_000_000n})
+        ]);
+
+        // package-1 illisible AVANT le probe → écarté à la construction.
+        await chmod(p1.files.energyPath,0o000);
+
+        const probe = await raplProbe(tmp);
+        const reader = new RaplReader({probe,log:'silent'});
+
+        await reader.sample(nowNs(0)); //prime
+        await writeFile(p0.files.energyPath,String(1_500_000n),'utf-8');
+        const sample = await reader.sample(nowNs(1.0));
+
+        assert.ok(sample);
+        //materiel a détecté 2 packa    ges, même si un a été écarté au démarage
+        assert.strictEqual(sample.expectedPackages,2);
+        //on en a lu qu'un seul
+        assert.strictEqual(sample.readablePackages,1);
+
+    } finally {
+        await rm(tmp,{recursive:true,force:true});
+    }
+});
+
+test('RaplReader - package becoming unreadable mid-run lowers readablePackage only', async() => {
+    const tmp = path.join(os.tmpdir(), `rapl-partial-midrun-${process.pid}`);
+    try {
+
+        const [p0,p1] = await Promise.all([
+             createRaplPackages(tmp,'intel-rapl:0',{name:'package-0',energy:1_000_000n}),
+            createRaplPackages(tmp,'intel-rapl:1',{name:'package-0',energy:2_000_000n})
+        ]);
+
+        const probe = await raplProbe(tmp);
+        const reader = new RaplReader({probe,log:'silent'});
+
+        await reader.sample(nowNs(0)); //prime 2 ppackages connus
+
+         // package-1 casse aprés probe.
+        await chmod(p1.files.energyPath,0o000);
+
+        await writeFile(p0.files.energyPath,String(1_500_000n),'utf-8');
+        const sample = await reader.sample(nowNs(1.0));
+
+        assert.ok(sample);
+        //2 packages attendus
+        assert.strictEqual(sample.expectedPackages,2);
+        //un seul a pu etre lu sur ce tick
+        assert.strictEqual(sample.readablePackages,1);
+
+    } finally {
+        await rm(tmp,{recursive:true,force:true});
+    }
+});

--- a/packages/energy-core/src/sensors/rapl/RaplReader.test.ts
+++ b/packages/energy-core/src/sensors/rapl/RaplReader.test.ts
@@ -32,7 +32,7 @@ test('RaplReader - sample energy consumption', async (t) => {
                 deltaUj:0,
                 wraps:0,
                 unhandledWraps:0,
-                ok:true
+                ok:true,
             };
             const expectedPrime = {
                 ok: true,
@@ -45,7 +45,9 @@ test('RaplReader - sample energy consumption', async (t) => {
                     expectedPackage
                 ],
                 wraps: 0,
-                unhandledWraps:0
+                unhandledWraps:0,
+                expectedPackages:1,
+                readablePackages:1
             }
             assert.ok(sample);
             assert.deepStrictEqual(sample, expectedPrime);
@@ -99,7 +101,9 @@ test('RaplReader - sample energy consumption', async (t) => {
                     }
                 ],
                 wraps: 0,
-                unhandledWraps:0
+                unhandledWraps:0,
+                expectedPackages:1,
+                readablePackages:1
             }
             assert.ok(sample);
             assert.deepStrictEqual(sample, expectedSecond);
@@ -152,6 +156,8 @@ test('RaplReader - sample energy consumption', async (t) => {
                 ],
                 wraps: 1,
                 unhandledWraps:0,
+                expectedPackages:1,
+                readablePackages:1
             }
             assert.ok(sample);
             assert.deepStrictEqual(sample, expectedWrap);
@@ -223,7 +229,9 @@ test('RaplReader - sample energy consumption', async (t) => {
 
                 ],
                 wraps: 0,
-                unhandledWraps:0
+                unhandledWraps:0,
+                expectedPackages:2,
+                readablePackages:2
             }
             assert.ok(sample);
             assert.deepStrictEqual(sample, expectedMulti);

--- a/packages/energy-core/src/sensors/rapl/RaplReader.ts
+++ b/packages/energy-core/src/sensors/rapl/RaplReader.ts
@@ -24,7 +24,9 @@ export interface RaplSample {
     deltaJ: number;    // J
     packages: RaplPackageSample[];
     wraps: number;
-    unhandledWraps: number; // total des wraps non mesurables sur ce tick
+    unhandledWraps: number; // total des wraps non mesurables sur ce tick,
+    expectedPackages: number;   // packages exposés par le matériel (figé au démarrage)
+    readablePackages: number;   // packages effectivement lus sur ce tick
 }
 
 interface RaplReaderPackageState {
@@ -50,6 +52,7 @@ export class RaplReader {
     private log: 'silent' | 'debug';
     private probeStatus: string | null = null;
     private probeHints: string | null = null;
+    private expectedPackages = 0;
 
     public readonly mode = 'rapl';
 
@@ -75,6 +78,10 @@ export class RaplReader {
             }
             return;
         }
+        // Choix honnête : ce que le matériel expose, capturé AVANT
+        // le filtrage de lisibilité, pour qu'un package déjà cassé au probe reste
+        // comptabilisé comme manquant.
+        this.expectedPackages = (probe.packages || []).length;
 
         const packages: RaplPackageInfo[] = (probe.packages || []).filter(
             (p: RaplPackageInfo) => p.hasEnergyReadable && p.files.energyUj,
@@ -168,6 +175,7 @@ export class RaplReader {
             }));
 
             const ok = primeResults.some((r) => r.ok);
+            const readablePackages = primeResults.filter((r) =>r.ok).length;
 
             // primed = false :  not exploitable delta yet
             return {
@@ -179,6 +187,8 @@ export class RaplReader {
                 packages,
                 wraps: 0,
                 unhandledWraps:0,
+                expectedPackages:this.expectedPackages,
+                readablePackages,
             };
         }
 
@@ -287,7 +297,9 @@ export class RaplReader {
                 deltaJ: 0,
                 packages: packageSamples,
                 wraps: Number(wraps),
-                unhandledWraps:Number(unhandledWraps)
+                unhandledWraps:Number(unhandledWraps),
+                expectedPackages:this.expectedPackages,
+                readablePackages:successfulReads
             };
         }
 
@@ -302,7 +314,9 @@ export class RaplReader {
             deltaJ: totalDeltaJ,
             packages: packageSamples,
             wraps: Number(wraps),
-            unhandledWraps:Number(unhandledWraps)
+            unhandledWraps:Number(unhandledWraps),
+            expectedPackages:this.expectedPackages,
+            readablePackages:successfulReads,
         };
     }
 


### PR DESCRIPTION
A machine can expose several RAPL packages (one per socket). When only some were read, the reader used to surface one package's energy as if it were the whole machine's, silently under-measuring. It now reports two facts on each sample: expectedPackages (hardware count, captured before readability filtering) and readablePackages (actually read this tick). ok stays permissive; the audit layer will decide the tolerance policy. Covers both a package unreadable at probe time and one failing mid-run. Empirical fallback reports 0/0.