### PR TITLE
fix(energy-core): parse /proc stat counters as bigint, report malform…

### DIFF
--- a/packages/energy-core/src/sensors/cpus/ProcessCpuReader.parse.test.ts
+++ b/packages/energy-core/src/sensors/cpus/ProcessCpuReader.parse.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import os from 'node:os';
+import { rm, writeFile, mkdir } from 'node:fs/promises';
+import { parsePidStatFile } from './ProcessCpuReader.js';
+
+// Fabrique un faux /proc/<pid>/stat avec un contenu donné, renvoie son chemin.
+async function writeStat(dir: string, content: string): Promise<string> {
+    await mkdir(dir, { recursive: true });
+    const p = path.join(dir, 'stat');
+    await writeFile(p, content, 'utf8');
+    return p;
+}
+
+// Cas A : fichier tronqué (le process est mort en cours de lecture).
+// Les champs après comm manquent -> ne doit PAS throw, doit rapporter une
+// erreur explicite, pas 'unknown'.
+test('parsePidStatFile - truncated stat reports malformed_stat, does not throw', async () => {
+    const dir = path.join(os.tmpdir(), `procstat-trunc-${process.pid}`);
+    try {
+        // "1234 (bash) R" puis plus rien : utime/stime/starttime absents.
+        const statPath = await writeStat(dir, '1234 (bash) R');
+        const snap = await parsePidStatFile(statPath);
+
+        assert.strictEqual(snap.ok, false);
+        if (snap.ok === false) {
+            assert.strictEqual(snap.error, 'malformed_stat');
+        }
+    } finally {
+        await rm(dir, { recursive: true, force: true });
+    }
+});
+
+// Cas B : un champ numérique requis n'est pas un nombre.
+test('parsePidStatFile - non-numeric required field reports malformed_stat', async () => {
+    const dir = path.join(os.tmpdir(), `procstat-nan-${process.pid}`);
+    try {
+        // On construit un stat avec utime = "xyz" (champ 14, donc index 11 après comm).
+        // pid comm state ppid pgrp session tty_nr tpgid flags minflt cminflt majflt cmajflt utime ...
+        const fields = ['R', '1', '1', '0', '0', '0', '0', '0', '0', '0', '0', 'xyz', '0', '0', '0'];
+        const statPath = await writeStat(dir, `1234 (bash) ${fields.join(' ')}`);
+        const snap = await parsePidStatFile(statPath);
+
+        assert.strictEqual(snap.ok, false);
+        if (snap.ok === false) {
+            assert.strictEqual(snap.error, 'malformed_stat');
+        }
+    } finally {
+        await rm(dir, { recursive: true, force: true });
+    }
+});
+
+// Cas C : starttime au-delà de 2^53 doit survivre sans perte de précision.
+test('parsePidStatFile - large starttime preserved without precision loss', async () => {
+    const dir = path.join(os.tmpdir(), `procstat-big-${process.pid}`);
+    const bigStart = '9007199254740993'; // 2^53 + 1, non représentable en Number
+    try {
+        // On place des valeurs valides jusqu'à starttime (champ 22, index 19 après comm).
+        // Indices après comm : 0=state 1=ppid ... 11=utime 12=stime 13=cutime 14=cstime
+        // ... 19=starttime
+        const after = [
+            'R', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', // state..cmajflt (0..10)
+            '100', '200', '0', '0',                                // utime stime cutime cstime (11..14)
+            '0', '0', '0', '0',                                    // priority nice num_threads itrealvalue (15..18)
+            bigStart,                                              // starttime (19)
+        ];
+        const statPath = await writeStat(dir, `1234 (bash) ${after.join(' ')}`);
+        const snap = await parsePidStatFile(statPath);
+
+        assert.strictEqual(snap.ok, true);
+        if (snap.ok === true) {
+            assert.strictEqual(snap.starttime, BigInt(bigStart));
+            assert.strictEqual(snap.utime, 100n);
+            assert.strictEqual(snap.stime, 200n);
+        }
+    } finally {
+        await rm(dir, { recursive: true, force: true });
+    }
+});

--- a/packages/energy-core/src/sensors/cpus/ProcessCpuReader.ts
+++ b/packages/energy-core/src/sensors/cpus/ProcessCpuReader.ts
@@ -44,7 +44,7 @@ export type ProcessStatSnapshot =
     | ProcessStatErrorSnapshot;
 
 interface ProcessCpuReaderState {
-    last_app_ticks: bigint | null;//utime + stime at last tick 
+    last_app_ticks: bigint | null;//utime + stime at last tick
     last_start_time_ticks: bigint | null;//starttime of process at last tick
     primed: boolean;//fist read has been done
 }
@@ -60,12 +60,31 @@ const STAT_FIELDS_NAME = [
     'env_start', 'env_end', 'exit_code'
 ];
 
+/** Erreur levée quand un champ requis de /proc/<pid>/stat est absent ou non entier. */
+class MalformedStatError extends Error {
+    constructor(message:string) {
+        super(message);
+        this.name = 'MalformedStatError';
+    }
+}
+/**
+ * Parse un compteur entier de /proc/<pid>/stat directement en bigint.
+ * Les compteurs (jiffies, starttime) sont toujours des entiers : on évite
+ * Number() qui perdrait la précision au-delà de 2^53 et produirait NaN sur
+ * un champ absent (fichier tronqué quand le process meurt en cours de lecture).
+ */
+function parseStatBigInt(raw:string | undefined,field:string):bigint {
+    if(raw === undefined || !/^-?\d+$/.test(raw)) {
+        throw new MalformedStatError(`missing or non-integer field "${field}": ${raw}`);
+    }
+    return BigInt(raw);
+}
 /**
  * check if a PID is valid
  * must exclusively be a non-negative integer
  * must exclude pid 0 (system idle process) and process.pid (current process)
- * @param pid 
- * @returns 
+ * @param pid
+ * @returns
  */
 export function pidIsValid(pid: number): boolean {
     if (pid < 0 || !Number.isInteger(pid) || pid === 0) {
@@ -93,37 +112,36 @@ export async function parsePidStatFile(statFilePath: string): Promise<ProcessSta
             pid,
             comm
         };
-
-        const fields = STAT_FIELDS_NAME.slice(2); // skip 'pid' and 'comm' as they are already handled
         const values = rest;
 
-        for (let i = 0; i < fields.length; i++) {
-            const field = fields[i];
-            const raw = values[i];
-            if (i === 0) {
-                // state is string
-                pidStat[field] = raw ?? null;
-            } else {
-                const num = Number(raw);
-                pidStat[field] = Math.abs(num) > Number.MAX_SAFE_INTEGER ? BigInt(raw) : num;
-            }
+        const state = values[0];
+        if(state === undefined) {
+            throw new MalformedStatError(`missing field "state`);
+        }
+
+        const ppidRaw = values[1];
+        if(ppidRaw === undefined || !/^-?\d+$/.test(ppidRaw)) {
+            throw new MalformedStatError(`missing or non-integer field "ppid": ${ppidRaw}`);
         }
         const snapshot: ProcessStatSnapshot = {
             ok: true,
             timeStamp: new Date().toISOString(),
             pid,
-            comm: pidStat.comm as string,
-            state: pidStat.state as string,
-            ppid: Number(pidStat.ppid),
-            utime: BigInt(pidStat.utime as number | bigint | string),
-            stime: BigInt(pidStat.stime as number | bigint | string),
-            cutime: BigInt(pidStat.cutime as number | bigint | string),
-            cstime: BigInt(pidStat.cstime as number | bigint | string),
-            starttime: BigInt(pidStat.starttime as number | bigint | string),
+            comm,
+            state,
+            ppid: Number(ppidRaw),
+            utime: parseStatBigInt(values[11], 'utime'),
+            stime: parseStatBigInt(values[12], 'stime'),
+            cutime: parseStatBigInt(values[13], 'cutime'),
+            cstime: parseStatBigInt(values[14], 'cstime'),
+            starttime: parseStatBigInt(values[19], 'starttime'),
         };
 
         return snapshot;
     } catch (error) {
+        if(error instanceof MalformedStatError) {
+            return { ok: false, error: 'malformed_stat'};
+        }
         const code = extractErrorCode(error);
 
         return {
@@ -159,7 +177,7 @@ export class ProcessCpuReader {
         this.statFilePath = options.statFilePath ?? `/proc/${this.pid}/stat`;
 
         this.state = {
-            last_app_ticks: null,//utime + stime at last tick 
+            last_app_ticks: null,//utime + stime at last tick
             last_start_time_ticks: null,//starttime of process at last tick
             primed: false//fist read has been done
         }


### PR DESCRIPTION
…ed stat

A truncated /proc/<pid>/stat (process dying mid-read) left required counter fields undefined; Number(undefined) became NaN and BigInt(NaN) threw, caught and reported as the opaque 'unknown'. Parse counters directly to bigint from their string form (they are always integers), validating each required field, and return an explicit 'malformed_stat' on truncated or non-numeric content. This also removes the Number() round-trip that silently lost precision on counters above 2^53 (e.g. starttime on high-uptime machines).