### PR TITLE
fix(energy-core): exclude steal time from active CPU ticks

### DIFF
--- a/packages/energy-core/src/sensors/cpus/CpuReader.steal.test.ts
+++ b/packages/energy-core/src/sensors/cpus/CpuReader.steal.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeCpuUtilization } from './CpuReader.js';
+
+// steal = temps où l'hyperviseur a retiré le CPU à cette VM. Le process ne
+// tourne pas pendant ce temps (il n'accumule ni utime ni stime), donc pour que
+// le ratio process/machine soit cohérent, steal ne doit compter ni dans active
+// ni dans total.
+test('computeCpuUtilization - steal is excluded from active and total', () => {
+    const base = {
+        user: 100n, nice: 0n, system: 50n,
+        idle: 200n, iowait: 0n,
+        irq: 0n, softirq: 0n,
+        steal: 0n,
+    };
+
+    const withoutSteal = computeCpuUtilization(base);
+    const withSteal = computeCpuUtilization({ ...base, steal: 300n });
+
+    // Ajouter du steal ne doit changer NI active NI total.
+    assert.strictEqual(withSteal.active, withoutSteal.active,
+        'steal must not inflate active');
+    assert.strictEqual(withSteal.total, withoutSteal.total,
+        'steal must not inflate total');
+
+    // Valeurs attendues explicites : active = user+nice+system+irq+softirq = 150,
+    // idle = idle+iowait = 200, total = 350. steal absent.
+    assert.strictEqual(withSteal.active, 150n);
+    assert.strictEqual(withSteal.idle, 200n);
+    assert.strictEqual(withSteal.total, 350n);
+});

--- a/packages/energy-core/src/sensors/cpus/CpuReader.ts
+++ b/packages/energy-core/src/sensors/cpus/CpuReader.ts
@@ -155,8 +155,7 @@ export function computeCpuUtilization(snapshot: CpuTimes): CpuTotal {
         snapshot.nice +
         snapshot.system +
         snapshot.irq +
-        snapshot.softirq +
-        snapshot.steal;
+        snapshot.softirq;
 
     return { idle, active, total: idle + active };
 }
@@ -191,7 +190,7 @@ export class CpuReader {
 
     async sample(nowNs: bigint): Promise<CpuSample | CpuSampleError> {
         const snapshot = await parseProcStat(this.statFilePath);
-        
+
         if (snapshot.ok === false) {
             return { ok: false, error: snapshot.error };
         }
@@ -223,7 +222,7 @@ export class CpuReader {
             };
         }
 
-        // --- 2) calculate deltas --- 
+        // --- 2) calculate deltas ---
 
         // log debug
         if (this.log === "debug" && process.stdout.isTTY) {


### PR DESCRIPTION
steal is time the hypervisor took the physical CPU away from this VM; the target process does not run during it and accumulates no utime/stime. Counting it as active inflated the attribution denominator, under-crediting each process and absorbing energy actually spent on co-tenants. Exclude steal from active (and thus total), keeping the machine-side base consistent with per-process jiffies. The field is still parsed and kept in CpuTimes for future reporting. Matters for virtualized/containerized infrastructure, the primary target.